### PR TITLE
Convert to vanilla codemirror

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "date-fns": "^2.29.3",
     "uuid": "^9.0.0",
     "vue": "^3.2.45",
-    "vue-codemirror": "^6.1.1",
     "vue-markdown-render": "^2.0.0"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,7 +19,6 @@ specifiers:
   vite: ^4.0.0
   vitest: ^0.26.3
   vue: ^3.2.45
-  vue-codemirror: ^6.1.1
   vue-markdown-render: ^2.0.0
   vue-tsc: ^1.0.11
 
@@ -35,7 +34,6 @@ dependencies:
   date-fns: 2.29.3
   uuid: 9.0.0
   vue: 3.2.45
-  vue-codemirror: 6.1.1_vhikcdkubtgbuxk47tdob2ofvi
   vue-markdown-render: 2.0.0
 
 devDependencies:
@@ -1396,20 +1394,6 @@ packages:
       - supports-color
       - terser
     dev: true
-
-  /vue-codemirror/6.1.1_vhikcdkubtgbuxk47tdob2ofvi:
-    resolution: {integrity: sha512-rTAYo44owd282yVxKtJtnOi7ERAcXTeviwoPXjIc6K/IQYUsoDkzPvw/JDFtSP6T7Cz/2g3EHaEyeyaQCKoDMg==}
-    peerDependencies:
-      codemirror: 6.x
-      vue: 3.x
-    dependencies:
-      '@codemirror/commands': 6.1.3
-      '@codemirror/language': 6.3.2
-      '@codemirror/state': 6.2.0
-      '@codemirror/view': 6.7.2
-      codemirror: 6.0.1
-      vue: 3.2.45
-    dev: false
 
   /vue-markdown-render/2.0.0:
     resolution: {integrity: sha512-t11tT8PdOe43GGDq7LSJVzy6hVPw8JX2YI5IXKEakfTZnHxSw/8pHeLrihCHxn4KP3+Xz+pxeM5LxUNpHFjn8Q==}

--- a/src/App.vue
+++ b/src/App.vue
@@ -80,7 +80,7 @@ onMounted(() => {
     }"
   >
     <Aside v-if="store.asideActive" />
-    <Editor />
+    <Editor v-model="store.activeNoteContents" />
     <MarkdownPreview v-if="store.loadedData.markdownPreviewActive" />
   </main>
 </template>

--- a/src/components/AsideSearch.vue
+++ b/src/components/AsideSearch.vue
@@ -24,24 +24,11 @@ const handleSearchKeydownEnter = () => {
   const codeMirror = store.elementRefs.codeMirror;
 
   if (noMatchingNoteFound) {
-    createNewNote(`# ${currentQuery.value} \n\n`);
+    createNewNote(`# ${currentQuery.value} \n`);
     handleInputChange("");
     currentQuery.value = "";
     saveAllNoteData();
-
-    if (codeMirror) {
-      setTimeout(() => {
-        // @ts-ignore: Property 'dispatch' does not exist on type 'never'.ts(2339)
-        codeMirror.dispatch({
-          selection: {
-            anchor: store.activeNoteContents.length,
-            head: store.activeNoteContents.length,
-          },
-        });
-        // @ts-ignore: Property 'focus' does not exist on type 'never'.ts(2339)
-        codeMirror.focus();
-      }, 10);
-    }
+    store.searchJustCreatedNote = true;
   }
 };
 

--- a/src/components/Editor.test.ts
+++ b/src/components/Editor.test.ts
@@ -10,7 +10,12 @@ let appWrapper: VueWrapper | null = null;
 beforeEach(() => {
   store.loadedData = getDefaultNotesData();
   appWrapper = mount(App);
-  editorWrapper = mount(Editor);
+  // @ts-ignore
+  editorWrapper = mount(Editor, {
+    context: {
+      props: { modelValue: store.activeNoteContents },
+    },
+  });
 });
 
 afterEach(() => {
@@ -18,30 +23,18 @@ afterEach(() => {
   if (appWrapper) appWrapper.unmount;
 });
 
-describe("handleOnChange()", () => {
-  it("If a note is active, handleOnChange will modify the current note", () => {
+describe("The editor's responses to change", () => {
+  it("If a note is active, handleOnChange will modify the current note", async () => {
     store.activeNoteId = store.loadedData.notes[0].id;
     // @ts-ignore: Property 'handleOnChange' does not exist on type 'ComponentPublicInstance ts(2339)
-    const handleOnChange = editorWrapper?.vm.handleOnChange;
     const testContent = "some test content";
 
-    handleOnChange(testContent);
+    // @ts-ignore: Property 'myCodemirrorView' does not exist on type 'ComponentPublicInstance ts(2339)
+    await editorWrapper?.vm.myCodemirrorView.dispatch({
+      changes: { from: 0, insert: testContent },
+    });
 
     expect(store.loadedData.notes[0].content).toBe(testContent);
-  });
-
-  it("If no note is active, handleOnChange creates a new note with the new content", () => {
-    store.activeNoteId = null;
-    // @ts-ignore: Property 'handleOnChange' does not exist on type 'ComponentPublicInstance ts(2339)
-    const handleOnChange = editorWrapper?.vm.handleOnChange;
-    const testContent = "some test content";
-
-    handleOnChange(testContent);
-
-    const notes = store.loadedData.notes;
-    const lastNote = notes.at(-1);
-
-    expect(lastNote?.content).toBe(testContent);
   });
 
   // it("onChange the editor saves the changes to the current note", async () => {

--- a/src/components/Editor.vue
+++ b/src/components/Editor.vue
@@ -20,6 +20,7 @@ const emit = defineEmits(["update:modelValue"]);
 const props = defineProps(["modelValue"]);
 const codemirrorContainer = ref<Element | null>(null);
 let myCodemirrorView = new EditorView();
+const codeMirrorTriggeredNoteCreation = ref(false);
 
 const handleOnChange = (update: ViewUpdate) => {
   if (!update.docChanged) return;
@@ -32,6 +33,8 @@ const handleOnChange = (update: ViewUpdate) => {
     createNewNote();
     emit("update:modelValue", currentContent);
     saveCurrentNoteChange(currentContent);
+
+    codeMirrorTriggeredNoteCreation.value = true;
   }
 };
 
@@ -83,7 +86,7 @@ const resetCodemirrorView = () => {
   };
 
   myCodemirrorView = new EditorView(codeMirrorOptions);
-  myCodemirrorView.focus();
+  store.elementRefs.codeMirror = myCodemirrorView;
 };
 
 onMounted(() => {
@@ -95,6 +98,16 @@ watch(
   () => store.activeNoteId,
   () => {
     resetCodemirrorView();
+    if (codeMirrorTriggeredNoteCreation.value || store.searchJustCreatedNote) {
+      const codeMirrorContentsLength = myCodemirrorView.state.doc.length;
+      myCodemirrorView.focus();
+      myCodemirrorView.dispatch({
+        selection: { anchor: codeMirrorContentsLength },
+      });
+
+      store.searchJustCreatedNote = false;
+      codeMirrorTriggeredNoteCreation.value = false;
+    }
   }
 );
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,50 +1,6 @@
 import { createApp } from "vue";
 import "./style.css";
 import App from "./App.vue";
-import VueCodemirror from "vue-codemirror";
-import { defaultKeymap } from "@codemirror/commands";
-import { EditorState } from "@codemirror/state";
-import { EditorView, drawSelection, keymap } from "@codemirror/view";
-import { markdown, markdownLanguage } from "@codemirror/lang-markdown";
-import { syntaxHighlighting, HighlightStyle } from "@codemirror/language";
-import { tags } from "@lezer/highlight";
-import { editorTheme } from "./editorTheme";
-
-const highlightStyle = HighlightStyle.define([
-  { tag: tags.strikethrough, class: "md-strikethrough" },
-  {
-    tag: [
-      tags.heading1,
-      tags.heading2,
-      tags.heading3,
-      tags.heading4,
-      tags.heading5,
-      tags.heading6,
-    ],
-    class: "md-header",
-  },
-  { tag: tags.emphasis, fontStyle: "italic", class: "md-emphasis" },
-  { tag: tags.strong, fontWeight: "600", class: "md-strong" },
-  { tag: tags.monospace, class: "md-monospace" },
-  { tag: tags.meta, class: "md-meta" },
-  { tag: tags.link, class: "md-link" },
-]);
-
-const codeMirrorOptions = {
-  extensions: [
-    markdown({
-      base: markdownLanguage,
-    }),
-    editorTheme,
-    EditorView.lineWrapping,
-    EditorState.allowMultipleSelections.of(true),
-    syntaxHighlighting(highlightStyle),
-    drawSelection(),
-    keymap.of(defaultKeymap),
-  ],
-  allowMultipleSelections: true,
-};
 
 const app = createApp(App);
-app.use(VueCodemirror, codeMirrorOptions);
 app.mount("#app");

--- a/src/store.ts
+++ b/src/store.ts
@@ -1,3 +1,4 @@
+import { EditorView } from "@codemirror/view";
 import { reactive } from "vue";
 
 export const store = reactive({
@@ -5,8 +6,9 @@ export const store = reactive({
   asideActive: true,
   matchingNotes: <Note[] | null>null,
   activeNoteId: <string | null>"",
+  searchJustCreatedNote: false,
   elementRefs: {
-    codeMirror: null,
+    codeMirror: <null | EditorView>null,
   },
   loadedData: <LoadedNotesData>{
     markdownPreviewActive: true,


### PR DESCRIPTION
I was using a package called `vue-codemirror` it spared me from a lot of complexity and made it _super_ easy to incorporate CodeMirror into this project. But I kept running into issue where features I wanted to implement were made more difficult because of the the abstractions and simplification of the package. So I decided to just implement codemirror myself manually.

IT took like two days but I did it.