### PR TITLE
Handle event listening plus the setting

### DIFF
--- a/src/components/SettingsView.vue
+++ b/src/components/SettingsView.vue
@@ -3,6 +3,7 @@ import Icon from "./Icon.vue";
 import { sendLocalNotesToDB, loadExistingDBData } from "../lib/supabase";
 import Button from "./Button.vue";
 import Select from "./Select.vue";
+import Switch from "./Switch.vue";
 import {
   signInWithGitHub,
   signInWithGoogle,
@@ -207,6 +208,26 @@ const handleLocalNotesImportClick = async () => {
                 <option value="dateCreated">Date created</option>
               </Select>
             </div>
+
+            <div class="settings-row">
+              <div class="settings-row-copy">
+                <label class="settings-row-heading" for="notes-sorting"
+                  >Note list secondary text</label
+                >
+                <p class="settings-row-description">
+                  Choose what data shows just below the note title in your note
+                  list.
+                </p>
+              </div>
+              <Select
+                id="notes-sorting"
+                v-model="settings.notePreviewContents"
+                @change="saveAppSettingsToLocalStorage"
+              >
+                <option value="dateModified">Modification date</option>
+                <option value="noteBody">Note contents</option>
+              </Select>
+            </div>
             <div class="settings-row">
               <div class="settings-row-copy">
                 <label class="settings-row-heading" for="notes-sorting"
@@ -231,22 +252,22 @@ const handleLocalNotesImportClick = async () => {
             </div>
             <div class="settings-row">
               <div class="settings-row-copy">
-                <label class="settings-row-heading" for="notes-sorting"
-                  >Note list item secondary data</label
+                <label class="settings-row-heading" for="syncScroll"
+                  >Sync scroll</label
                 >
                 <p class="settings-row-description">
                   Choose what data shows just below the note title in your note
                   list.
                 </p>
               </div>
-              <Select
-                id="notes-sorting"
-                v-model="settings.notePreviewContents"
+              <Switch
+                label-for="syncScroll"
+                v-model="settings.syncScroll"
                 @change="saveAppSettingsToLocalStorage"
               >
                 <option value="dateModified">Modification date</option>
                 <option value="noteBody">Note contents</option>
-              </Select>
+              </Switch>
             </div>
           </div>
         </div>

--- a/src/lib/localStorage.ts
+++ b/src/lib/localStorage.ts
@@ -31,6 +31,7 @@ export const saveAppSettingsToLocalStorage = () => {
     localDataParsed.noteOrderPreference = settings.noteOrderPreference;
     localDataParsed.notePreviewContents = settings.notePreviewContents;
     localDataParsed.fullWidthNotes = settings.fullWidthNotes;
+    localDataParsed.syncScroll = settings.syncScroll;
 
     localStorage.setItem("volon", JSON.stringify(localDataParsed));
   } else {
@@ -66,6 +67,7 @@ export const loadAppSettingsFromLocalStorage = () => {
     settings.notePreviewContents =
       localDataParsed.notePreviewContents ?? "noteBody";
     settings.fullWidthNotes = localDataParsed.fullWidthNotes ?? "never";
+    settings.syncScroll = localDataParsed.syncScroll ?? false;
   } else {
     createNewAppSettingsInLocalStorage();
   }

--- a/src/stores/store.elementRefs.ts
+++ b/src/stores/store.elementRefs.ts
@@ -7,6 +7,7 @@ export const useElementRefsStore = defineStore("elementRefs", {
       codeMirror: <null | EditorView>null,
       codemirrorContainer: <null | HTMLDivElement>null,
       asideSearchInput: <null | HTMLInputElement>null,
+      markdownPreviewContainer: <null | HTMLDivElement>null,
       commandPaletteSearchInput: <null | HTMLInputElement>null,
       asideNoteListContainer: <null | HTMLDivElement>null,
       editorAndPreview: <null | HTMLElement>null,

--- a/src/stores/store.genericState.ts
+++ b/src/stores/store.genericState.ts
@@ -14,6 +14,7 @@ export const useGenericStateStore = defineStore("genericState", {
       commandPaletteCurrentQuery: "",
       urlHasSearch: false,
       columnIsBeingResized: false,
+      scrollSyncActiveSection: "both",
     };
   },
   actions: {

--- a/src/stores/store.settings.ts
+++ b/src/stores/store.settings.ts
@@ -10,6 +10,7 @@ export const useSettingsStore = defineStore("settings", {
       notePreviewContents: "dateModified",
       userColorSchemePreference: "light",
       fullWidthNotes: "never",
+      syncScroll: false,
     };
   },
   actions: {

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -21,6 +21,7 @@ interface settingsStore {
   notePreviewContents: "dateModified" | "noteBody";
   userColorSchemePreference: "dark" | "light";
   fullWidthNotes: "never" | "always" | "whenPreviewActive";
+  syncScroll: boolean;
 }
 
 interface MenuItem {


### PR DESCRIPTION
Added an option to keep the scroll position of a note in sync with it's markdown preview.